### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Move theme folders to `~/.local/share/themes/`
 To install the Gtk4 theme move the contents of `gtk4.0` to `~/.config/gtk4.0`
 
 ### Flatpak
-To install themes on Flatpak apps use these commands:  
+To install themes on Flatpak apps use this command:  
 ```pwsh
-flatpak override --filesystem=$HOME/.local/share/themes
+sudo flatpak override --filesystem=$HOME/.local/share/themes:ro
 ```
+or use [flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) to give every application access to `~/.local/share/themes`
 
 ### Gnome-shell
 To install the gnome-shell theme, move the entire theme folders to `~/.local/share/themes`.

--- a/README.md
+++ b/README.md
@@ -40,10 +40,15 @@ To install the Gtk4 theme move the contents of `gtk4.0` to `~/.config/gtk4.0`
 
 ### Flatpak
 To install themes on Flatpak apps use this command:  
+For gtk3 applications:
 ```pwsh
 sudo flatpak override --filesystem=$HOME/.local/share/themes:ro
 ```
-or use [flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) to give every application access to `~/.local/share/themes:ro`
+For gtk4/libadwaita applications:
+```pwsh
+sudo flatpak override --filesystem=$HOME/.config/gtk-4.0:ro
+```
+or use [flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) to give every application access to `~/.local/share/themes:ro` and `xdg-config/gtk-4.0:ro`
 
 ### Gnome-shell
 To install the gnome-shell theme, move the entire theme folders to `~/.local/share/themes`.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To install themes on Flatpak apps use this command:
 ```pwsh
 sudo flatpak override --filesystem=$HOME/.local/share/themes:ro
 ```
-or use [flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) to give every application access to `~/.local/share/themes`
+or use [flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) to give every application access to `~/.local/share/themes:ro`
 
 ### Gnome-shell
 To install the gnome-shell theme, move the entire theme folders to `~/.local/share/themes`.

--- a/README.md
+++ b/README.md
@@ -33,26 +33,19 @@ Simple theme with nothing extra to use on a regular basis. Theme tested on Manja
 Download theme [here.](https://github.com/witalihirsch/Mono-gtk-theme/releases)
 
 ## Installation 
-Move theme folders to `/home/user/.themes/`
+Move theme folders to `~/.local/share/themes/`
 
 ### GTK4
-To install the Gtk4 theme move the contents of `gtk4.0` to `home/user/.config/gtk4.0`
+To install the Gtk4 theme move the contents of `gtk4.0` to `~/.config/gtk4.0`
 
 ### Flatpak
 To install themes on Flatpak apps use these commands:  
 ```pwsh
-sudo flatpak override --filesystem=$HOME/.themes
-```  
-```pwsh
-sudo flatpak override --env=GTK_THEME=MonoTheme
-```
-or
-```pwsh
-sudo flatpak override --env=GTK_THEME=MonoThemeDark
+flatpak override --filesystem=$HOME/.local/share/themes
 ```
 
 ### Gnome-shell
-To install the gnome-shell theme, move the entire theme folders to `/home/user/.themes`.
+To install the gnome-shell theme, move the entire theme folders to `~/.local/share/themes`.
 
 IMPORTANT! Take a snapshot of the system before use!  
 If you want the gnome-shell theme to extend to the lock and login screen, move the `gnome-shell-theme.gresource` file from `gnome-shell` folder to `/usr/share/gnome-shell/` with a replacement and restart system with `ALT+F2` and enter `r` or reboot/log out for Wayland session.  


### PR DESCRIPTION
This changes the installation path to `~/.local/share/themes` instead of `~/.themes`, which has the same effect but doesn't clutter the home directory and follows xdg directory standards.
It also removes the instructions for `GTK_THEME` as this tends to break things and is not meant to use for daily use, flatpak should automatically follow the host gtk theme.
And removes the `sudo` from the flatpak commands as running flatpak as root isn't very recommended.